### PR TITLE
Avoid comparing `String` and `Arc<String>`; call `as_str()` explicitly

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -107,7 +107,7 @@ impl PartialOrd for Value {
         match (self, other) {
             (Value::Num(lhs), Value::Num(rhs)) => f32::partial_cmp(lhs, rhs),
             (Value::Bool(lhs), Value::Bool(rhs)) => bool::partial_cmp(lhs, rhs),
-            (Value::Str(lhs), Value::Str(rhs)) => String::partial_cmp(lhs, rhs),
+            (Value::Str(lhs), Value::Str(rhs)) => str::partial_cmp(lhs.as_str(), rhs.as_str()),
             _ => None,
         }
     }


### PR DESCRIPTION
This improves robustness against inference errors if any new comparison
impls for strings become available.
